### PR TITLE
feat(glossary): support RDF business glossary ingestion

### DIFF
--- a/metadata-ingestion/docs/sources/business-glossary/datahub-business-glossary.md
+++ b/metadata-ingestion/docs/sources/business-glossary/datahub-business-glossary.md
@@ -1,6 +1,11 @@
 ### Business Glossary File Format
 
-The business glossary source file should be a .yml file with the following top-level keys:
+The business glossary source supports two input formats:
+
+- **YAML** (`.yml` / `.yaml`): The original hierarchical format described below.
+- **RDF / Turtle** (`.rdf`, `.owl`, `.ttl`, `.n3`): SKOS-based glossaries that are converted into DataHub terms during ingestion.
+
+When using YAML, the file should include the following top-level keys:
 
 **Glossary**: the top level keys of the business glossary file
 
@@ -68,6 +73,18 @@ Example **GlossaryTerm**:
       label: Wiki link
   domain: "urn:li:domain:Logistics" # (optional) domain name or domain urn
 ```
+
+### Working with RDF files
+
+When providing an RDF glossary, DataHub relies on the [SKOS vocabulary](https://www.w3.org/TR/skos-reference/) to interpret the concepts.
+
+- Each `skos:Concept` becomes a DataHub glossary term.
+- `skos:prefLabel` or `rdfs:label` is used as the term name.
+- `skos:definition` or `rdfs:comment` provides the term description.
+- `skos:broader` relationships are mapped to `inherits` relationships between terms.
+- Term URNs are generated automatically based on their labels, and `skos:ConceptScheme` metadata is used to populate the glossary source information.
+
+You can provide the RDF data either as a local file path or an HTTP(S) URL. Remote files are fetched at ingestion time.
 
 ## ID Management and URL Generation
 

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -45,6 +45,7 @@ framework_common = {
     "Deprecated",
     "humanfriendly",
     "packaging",
+    "rdflib>=6.2.0",
     "aiohttp<4",
     "cached_property",
     "ijson",

--- a/metadata-ingestion/tests/unit/test_business_glossary_rdf.py
+++ b/metadata-ingestion/tests/unit/test_business_glossary_rdf.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from datahub.ingestion.source.metadata.business_glossary import (
+    BusinessGlossaryFileSource,
+)
+
+
+@pytest.fixture(name="rdf_content")
+def fixture_rdf_content() -> str:
+    return """@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex: <http://example.org/> .
+
+ex:glossary a skos:ConceptScheme ;
+    skos:prefLabel "Example Glossary"@en .
+
+ex:termA a skos:Concept ;
+    skos:prefLabel "Term A"@en ;
+    skos:definition "Definition for term A"@en ;
+    skos:inScheme ex:glossary .
+
+ex:termB a skos:Concept ;
+    skos:prefLabel "Term B"@en ;
+    skos:definition "Definition for term B"@en ;
+    skos:broader ex:termA ;
+    skos:inScheme ex:glossary .
+"""
+
+
+def test_load_glossary_config_from_local_rdf(tmp_path: Path, rdf_content: str) -> None:
+    rdf_file = tmp_path / "glossary.ttl"
+    rdf_file.write_text(rdf_content)
+
+    config = BusinessGlossaryFileSource.load_glossary_config(rdf_file)
+
+    assert config.version == "1"
+    assert config.source == "Example Glossary"
+    assert config.url is None
+
+    term_names = [term.name for term in config.terms or []]
+    assert sorted(term_names) == ["Term A", "Term B"]
+
+    term_map = {term.name: term for term in config.terms or []}
+    assert term_map["Term A"].description == "Definition for term A"
+    assert term_map["Term B"].inherits == ["Term A"]
+
+
+def test_load_glossary_config_from_remote_rdf(rdf_content: str) -> None:
+    remote_url = "https://example.org/glossary.ttl"
+
+    with mock.patch("requests.get") as mock_get:
+        mock_response = mock.Mock()
+        mock_response.text = rdf_content
+        mock_response.raise_for_status = mock.Mock()
+        mock_get.return_value = mock_response
+
+        config = BusinessGlossaryFileSource.load_glossary_config(remote_url)
+
+    mock_get.assert_called_once_with(remote_url, timeout=30)
+    assert config.url == remote_url
+    assert config.source == "Example Glossary"


### PR DESCRIPTION
## Summary
- allow the business glossary source to ingest RDF and Turtle files from local paths or HTTP(S) URLs
- document the new RDF workflow and add rdflib to the ingestion dependencies
- add unit coverage for loading RDF glossaries and remote fetch handling

## Testing
- pytest --override-ini addopts= tests/unit/test_business_glossary_rdf.py

------
https://chatgpt.com/codex/tasks/task_e_68e1f9a7b15c832cb9d426472966cd7e