### PR TITLE
refactor: regroup import preview by entity type

### DIFF
--- a/datahub-web-react/src/app/SearchRoutes.tsx
+++ b/datahub-web-react/src/app/SearchRoutes.tsx
@@ -12,6 +12,7 @@ import DomainRoutesV2 from '@app/domainV2/DomainRoutes';
 import { ManageDomainsPage as ManageDomainsPageV2 } from '@app/domainV2/ManageDomainsPage';
 import { EntityPage } from '@app/entity/EntityPage';
 import { EntityPage as EntityPageV2 } from '@app/entityV2/EntityPage';
+import { ImportEntitiesPage } from '@app/import/ImportEntitiesPage';
 import GlossaryRoutes from '@app/glossary/GlossaryRoutes';
 import GlossaryRoutesV2 from '@app/glossaryV2/GlossaryRoutes';
 import StructuredProperties from '@app/govern/structuredProperties/StructuredProperties';
@@ -106,6 +107,7 @@ export const SearchRoutes = (): JSX.Element => {
                     />
                 )}
 
+                <Route path={PageRoutes.IMPORT_ENTITIES} render={() => <ImportEntitiesPage />} />
                 {!showIngestV2 && <Route path={PageRoutes.INGESTION} render={() => <ManageIngestionPage />} />}
                 {showIngestV2 && <Route path={PageRoutes.INGESTION} render={() => <ManageIngestionPageV2 />} />}
 

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavSidebar.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavSidebar.tsx
@@ -1,5 +1,6 @@
 import {
     AppWindow,
+    ArrowSquareDown,
     BookBookmark,
     Gear,
     Globe,
@@ -109,6 +110,7 @@ export const NavSidebar = () => {
     const showManageTags =
         config?.featureFlags?.showManageTags &&
         (me.platformPrivileges?.manageTags || me.platformPrivileges?.viewManageTags);
+    const showEntityImport = config?.featureFlags?.showEntityImport ?? true;
     const businessAttributesFlag = useBusinessAttributesFlag();
 
     const showDataSources =
@@ -227,6 +229,15 @@ export const NavSidebar = () => {
                         icon: <Plugs />,
                         selectedIcon: <Plugs weight="fill" />,
                         link: PageRoutes.INGESTION,
+                    },
+                    {
+                        type: NavBarMenuItemTypes.Item,
+                        title: 'Entity Import',
+                        key: 'entityImport',
+                        isHidden: !showEntityImport,
+                        icon: <ArrowSquareDown />,
+                        selectedIcon: <ArrowSquareDown weight="fill" />,
+                        link: PageRoutes.IMPORT_ENTITIES,
                     },
                     {
                         type: NavBarMenuItemTypes.Item,

--- a/datahub-web-react/src/app/import/ImportEntitiesPage.tsx
+++ b/datahub-web-react/src/app/import/ImportEntitiesPage.tsx
@@ -1,0 +1,501 @@
+import { gql, useMutation } from '@apollo/client';
+import { Button, PageTitle, Pagination, SearchBar, Tabs, Text } from '@components';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+
+import TabToolbar from '@app/entity/shared/components/styled/TabToolbar';
+import { ImportEntitiesTable, StatusSummary } from '@app/import/ImportEntitiesTable';
+import { DEFAULT_PAGE_SIZE } from '@app/import/constants';
+import {
+    ImportEntityAspect,
+    ImportEntityDraft,
+    ImportEntityDraftUpdate,
+    ImportEntityGroup,
+    ImportEntityRow,
+} from '@app/import/types';
+import { useImportEntities } from '@app/import/useImportEntities';
+import useShowToast from '@app/homeV3/toast/useShowToast';
+import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
+import { colors } from '@src/alchemy-components';
+
+const PageContainer = styled.div<{ $isShowNavBarRedesign?: boolean }>`
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 16px;
+    background-color: white;
+    border-radius: ${(props) =>
+        props.$isShowNavBarRedesign ? props.theme.styles['border-radius-navbar-redesign'] : '8px'};
+    ${(props) =>
+        props.$isShowNavBarRedesign &&
+        `
+        margin: 5px;
+        box-shadow: ${props.theme.styles['box-shadow-navbar-redesign']};
+    `}
+`;
+
+const PageHeaderContainer = styled.div`
+    padding: 0 20px 16px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+const TitleContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const HeaderActions = styled.div`
+    display: flex;
+    gap: 12px;
+`;
+
+const StyledTabToolbar = styled(TabToolbar)`
+    padding: 8px 20px;
+    box-shadow: none;
+    flex-shrink: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+const FiltersContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+`;
+
+const SummaryContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 20px;
+`;
+
+const StyledSearchBar = styled(SearchBar)`
+    width: 240px;
+`;
+
+const TableContainer = styled.div`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 0 20px;
+    overflow: hidden;
+`;
+
+const EmptyState = styled.div`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border: 1px dashed ${colors.gray[1400]};
+    border-radius: 8px;
+    margin-top: 16px;
+`;
+
+const PaginationContainer = styled.div`
+    padding: 12px 20px 16px;
+    display: flex;
+    justify-content: flex-end;
+`;
+
+type PatchOperation = {
+    op: 'add' | 'replace' | 'remove';
+    path: string;
+    value?: unknown;
+};
+
+type EntityPatchInput = {
+    urn: string;
+    entityType: string;
+    operations: PatchOperation[];
+};
+
+const PATCH_ENTITIES_MUTATION = gql`
+    mutation patchEntities($input: PatchEntitiesInput!) {
+        patchEntities(input: $input) {
+            status
+        }
+    }
+`;
+
+const flattenRows = (rows: ImportEntityRow[], map: Map<string, ImportEntityRow>) => {
+    rows.forEach((row) => {
+        map.set(row.urn, row);
+        if (row.children?.length) {
+            flattenRows(row.children, map);
+        }
+    });
+};
+
+const buildOriginalMap = (groups: ImportEntityGroup[]) => {
+    const map = new Map<string, ImportEntityRow>();
+    groups.forEach((group) => flattenRows(group.rows, map));
+    return map;
+};
+
+const normalizeAspectString = (value?: string | null) => {
+    if (value === null || value === undefined) {
+        return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return '';
+    }
+    try {
+        return JSON.stringify(JSON.parse(value));
+    } catch (e) {
+        return trimmed;
+    }
+};
+
+const parseAspectValue = (value?: string | null) => {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return '';
+    }
+    try {
+        return JSON.parse(value);
+    } catch (e) {
+        return value;
+    }
+};
+
+const buildPatchOperations = (draft: ImportEntityDraft, original: ImportEntityRow): PatchOperation[] => {
+    const operations: PatchOperation[] = [];
+    const previewName = original.name;
+    const targetName = draft.name ?? previewName;
+    if (targetName !== original.originalName) {
+        operations.push({ op: 'replace', path: '/name', value: targetName });
+    }
+
+    const previewDescription = original.description ?? '';
+    const targetDescription = draft.description ?? previewDescription ?? '';
+    const originalDescription = original.originalDescription ?? '';
+    if (targetDescription !== originalDescription) {
+        operations.push({ op: 'replace', path: '/description', value: targetDescription });
+    }
+
+    const aspectOverrides = draft.aspects || {};
+    const aspectMap = new Map<string, ImportEntityAspect>();
+    original.aspects?.forEach((aspect) => {
+        aspectMap.set(aspect.name, aspect);
+    });
+    const aspectNames = new Set<string>([
+        ...Array.from(aspectMap.keys()),
+        ...Object.keys(aspectOverrides),
+    ]);
+
+    aspectNames.forEach((aspectName) => {
+        const aspect = aspectMap.get(aspectName);
+        const previewValue = aspect?.value ?? null;
+        const originalValue = aspect?.originalValue ?? null;
+        const overrideValue = aspectOverrides[aspectName];
+        const targetValue = overrideValue !== undefined ? overrideValue : previewValue;
+        if (targetValue === undefined) {
+            return;
+        }
+
+        const normalizedTarget = normalizeAspectString(targetValue);
+        const normalizedOriginal = normalizeAspectString(originalValue);
+
+        if (normalizedTarget === normalizedOriginal) {
+            return;
+        }
+
+        const parsedValue = parseAspectValue(targetValue);
+        if (parsedValue === undefined) {
+            return;
+        }
+
+        operations.push({
+            op: parsedValue === null ? 'remove' : 'replace',
+            path: `/aspects/${aspectName}`,
+            value: parsedValue,
+        });
+    });
+
+    return operations;
+};
+
+export const ImportEntitiesPage: React.FC = () => {
+    const isShowNavBarRedesign = useShowNavBarRedesign();
+    const { showToast } = useShowToast();
+
+    const [page, setPage] = useState(1);
+    const [searchValue, setSearchValue] = useState('');
+    const [query, setQuery] = useState<string | undefined>();
+    const [selectedEntityType, setSelectedEntityType] = useState<string | undefined>();
+    const [drafts, setDrafts] = useState<Record<string, ImportEntityDraft>>({});
+
+    const start = (page - 1) * DEFAULT_PAGE_SIZE;
+
+    const { data, loading, error, refetch } = useImportEntities({
+        start,
+        count: DEFAULT_PAGE_SIZE,
+        query,
+    });
+
+    const originalByUrn = useMemo(() => buildOriginalMap(data.groups), [data.groups]);
+
+    useEffect(() => {
+        setDrafts((prev) => {
+            const nextEntries = Object.entries(prev).filter(([urn]) => originalByUrn.has(urn));
+            if (nextEntries.length === Object.keys(prev).length) {
+                return prev;
+            }
+            return Object.fromEntries(nextEntries);
+        });
+    }, [originalByUrn]);
+
+    useEffect(() => {
+        if (!data.groups.length) {
+            setSelectedEntityType(undefined);
+            return;
+        }
+        if (!selectedEntityType || !data.groups.some((group) => group.id === selectedEntityType)) {
+            setSelectedEntityType(data.groups[0].id);
+        }
+    }, [data.groups, selectedEntityType]);
+
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setPage(1);
+            setQuery(searchValue ? searchValue : undefined);
+        }, 300);
+        return () => clearTimeout(handler);
+    }, [searchValue]);
+
+    const [patchEntities, { loading: isImporting }] = useMutation(PATCH_ENTITIES_MUTATION);
+
+    const patches: EntityPatchInput[] = useMemo(() => {
+        return Array.from(originalByUrn.entries())
+            .map(([urn, original]) => {
+                const draft = drafts[urn] || {};
+                const operations = buildPatchOperations(draft, original);
+                if (!operations.length) return null;
+                return {
+                    urn,
+                    entityType: original.entityType,
+                    operations,
+                };
+            })
+            .filter((patch): patch is EntityPatchInput => patch !== null);
+    }, [drafts, originalByUrn]);
+
+    const pendingPatchCount = patches.length;
+
+    const handleUpdateDraft = useCallback(
+        (urn: string, updates: ImportEntityDraftUpdate) => {
+            setDrafts((prev) => {
+                const original = originalByUrn.get(urn);
+                if (!original) {
+                    return prev;
+                }
+
+                const existing = prev[urn] || {};
+                const nextName = updates.name !== undefined ? updates.name : existing.name;
+                const nextDescription =
+                    updates.description !== undefined ? updates.description : existing.description;
+                const mergedAspects = updates.aspects
+                    ? { ...(existing.aspects || {}), ...updates.aspects }
+                    : existing.aspects;
+
+                const normalized: ImportEntityDraft = {};
+
+                if (nextName !== undefined && nextName !== original.name) {
+                    normalized.name = nextName;
+                }
+
+                if (nextDescription !== undefined && nextDescription !== (original.description ?? '')) {
+                    normalized.description = nextDescription;
+                }
+
+                if (mergedAspects) {
+                    const normalizedAspects: Record<string, string | null> = {};
+                    Object.entries(mergedAspects).forEach(([aspectName, value]) => {
+                        const previewAspect = original.aspects?.find((aspect) => aspect.name === aspectName);
+                        const previewValue = previewAspect?.value ?? null;
+                        const normalizedPreview = normalizeAspectString(previewValue);
+                        const normalizedNext = normalizeAspectString(value ?? '');
+                        if (normalizedNext !== normalizedPreview) {
+                            normalizedAspects[aspectName] = value ?? '';
+                        }
+                    });
+                    if (Object.keys(normalizedAspects).length) {
+                        normalized.aspects = normalizedAspects;
+                    }
+                }
+
+                const hasOverrides =
+                    normalized.name !== undefined ||
+                    normalized.description !== undefined ||
+                    (normalized.aspects && Object.keys(normalized.aspects).length > 0);
+
+                if (!hasOverrides) {
+                    if (!prev[urn]) {
+                        return prev;
+                    }
+                    const nextDrafts = { ...prev };
+                    delete nextDrafts[urn];
+                    return nextDrafts;
+                }
+
+                return { ...prev, [urn]: normalized };
+            });
+        },
+        [originalByUrn],
+    );
+
+    const selectedGroup = useMemo(() => {
+        if (!data.groups.length) {
+            return undefined;
+        }
+        return data.groups.find((group) => group.id === selectedEntityType) || data.groups[0];
+    }, [data.groups, selectedEntityType]);
+
+    const tabs = useMemo(
+        () =>
+            data.groups.map((group) => ({
+                key: group.id,
+                name: group.label,
+                count: group.total,
+                component: (
+                    <ImportEntitiesTable
+                        rows={group.rows}
+                        drafts={drafts}
+                        loading={loading}
+                        onUpdateDraft={handleUpdateDraft}
+                    />
+                ),
+            })),
+        [data.groups, drafts, loading, handleUpdateDraft],
+    );
+
+    const activeTabKey = selectedEntityType || (tabs[0]?.key ?? '');
+
+    const handlePageChange = (nextPage: number) => {
+        setPage(nextPage);
+    };
+
+    const handleImport = async () => {
+        if (!patches.length) {
+            showToast('No changes to import', 'Select or edit rows to import metadata.');
+            return;
+        }
+        try {
+            await patchEntities({
+                variables: {
+                    input: {
+                        patches,
+                    },
+                },
+            });
+            showToast('Import started', 'We are applying your metadata updates.');
+            setDrafts((prev) => {
+                const next = { ...prev };
+                patches.forEach((patch) => {
+                    delete next[patch.urn];
+                });
+                return next;
+            });
+            refetch();
+        } catch (e: any) {
+            showToast('Import failed', e?.message || 'Unable to import entity changes.');
+        }
+    };
+
+    const pendingCopy = useMemo(() => {
+        if (!pendingPatchCount) {
+            return 'No pending changes';
+        }
+        const noun = pendingPatchCount === 1 ? 'change' : 'changes';
+        return `${pendingPatchCount} ${noun} ready`;
+    }, [pendingPatchCount]);
+
+    const disableImport = !pendingPatchCount || isImporting;
+
+    const totalPages = Math.ceil(data.total / DEFAULT_PAGE_SIZE);
+
+    return (
+        <PageContainer $isShowNavBarRedesign={isShowNavBarRedesign}>
+            <PageHeaderContainer>
+                <TitleContainer>
+                    <PageTitle
+                        title="Import Entities"
+                        subTitle="Review, edit, and apply metadata updates across entity groups."
+                    />
+                </TitleContainer>
+                <HeaderActions>
+                    <Button variant="outlined" onClick={() => refetch()} disabled={loading}>
+                        Refresh
+                    </Button>
+                    <Button variant="filled" onClick={handleImport} disabled={disableImport} loading={isImporting}>
+                        Import Entities
+                    </Button>
+                </HeaderActions>
+            </PageHeaderContainer>
+            <StyledTabToolbar>
+                <FiltersContainer>
+                    <StyledSearchBar
+                        value={searchValue}
+                        onChange={(value) => setSearchValue(value)}
+                        placeholder="Search entities"
+                        allowClear
+                    />
+                </FiltersContainer>
+                <SummaryContainer>
+                    <Text color="gray" size="sm">
+                        {pendingCopy}
+                    </Text>
+                    {selectedGroup && <StatusSummary counts={selectedGroup.statusCounts} />}
+                </SummaryContainer>
+            </StyledTabToolbar>
+            <TableContainer>
+                {error && (
+                    <Text color="red" size="sm" style={{ padding: '12px 0' }}>
+                        {error.message}
+                    </Text>
+                )}
+                {!loading && !data.total ? (
+                    <EmptyState>
+                        <Text weight="bold">No entities ready for import</Text>
+                        <Text color="gray" size="sm">
+                            Adjust your filters or upload a new import file to review metadata updates.
+                        </Text>
+                    </EmptyState>
+                ) : (
+                    tabs.length ? (
+                        <Tabs
+                            tabs={tabs}
+                            selectedTab={activeTabKey}
+                            onChange={(key) => setSelectedEntityType(key)}
+                            styleOptions={{ containerHeight: 'full' }}
+                        />
+                    ) : null
+                )}
+            </TableContainer>
+            {totalPages > 1 && (
+                <PaginationContainer>
+                    <Pagination
+                        currentPage={page}
+                        itemsPerPage={DEFAULT_PAGE_SIZE}
+                        total={data.total}
+                        onPageChange={handlePageChange}
+                    />
+                </PaginationContainer>
+            )}
+        </PageContainer>
+    );
+};
+
+export default ImportEntitiesPage;

--- a/datahub-web-react/src/app/import/ImportEntitiesTable.tsx
+++ b/datahub-web-react/src/app/import/ImportEntitiesTable.tsx
@@ -1,0 +1,402 @@
+import { Input, Pill, Table, Text, TextArea } from '@components';
+import { ColorValues, PillVariantValues } from '@components/theme/config';
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+
+import { IMPORT_STATUS_COPY } from '@app/import/constants';
+import {
+    ImportEntityAspect,
+    ImportEntityDraft,
+    ImportEntityDraftUpdate,
+    ImportEntityRow,
+    ImportEntityStatus,
+} from '@app/import/types';
+import { colors } from '@src/alchemy-components';
+
+const TableWrapper = styled.div`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    overflow: hidden;
+`;
+
+const InlineInput = styled(Input)`
+    width: 100%;
+    && {
+        margin-bottom: 0;
+    }
+    && label {
+        display: none;
+    }
+    && ${'' /* Hide helper text spacing */} div[data-testid='helper-text'] {
+        display: none;
+    }
+`;
+
+const InlineTextArea = styled(TextArea)`
+    width: 100%;
+    && {
+        margin-bottom: 0;
+    }
+    && label {
+        display: none;
+    }
+`;
+
+const StatusContainer = styled.div`
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+`;
+
+const StatusGroup = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+`;
+
+const EntityNameCell = styled.div<{ $level: number }>`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-left: ${(props) => props.$level * 20}px;
+`;
+
+const PathText = styled(Text)`
+    color: ${colors.gray[1700]};
+`;
+
+const ChangedField = styled.div`
+    border-left: 3px solid ${colors.violet[500]};
+    padding-left: 8px;
+`;
+
+const AspectList = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+`;
+
+const AspectItem = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+`;
+
+const AspectHeader = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+`;
+
+const AspectLabel = styled(Text)`
+    font-weight: 600;
+`;
+
+const AspectOriginalWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+`;
+
+const AspectOriginal = styled.pre`
+    margin: 0;
+    padding: 8px;
+    border-radius: 4px;
+    background-color: ${colors.gray[100]};
+    max-height: 160px;
+    overflow: auto;
+    font-size: 12px;
+    font-family: 'Roboto Mono', monospace;
+    white-space: pre-wrap;
+`;
+
+const NoAspectsText = styled(Text)`
+    color: ${colors.gray[1700]};
+`;
+
+type EntityRowData = {
+    key: string;
+    name: string;
+    urn: string;
+    displayName: string;
+    originalName: string;
+    description?: string | null;
+    originalDescription?: string | null;
+    entityType: string;
+    status: ImportEntityStatus;
+    path: string[];
+    level: number;
+    aspects?: ImportEntityAspect[];
+    children?: EntityRowData[];
+};
+
+type ImportEntitiesTableProps = {
+    rows: ImportEntityRow[];
+    drafts: Record<string, ImportEntityDraft>;
+    loading: boolean;
+    onUpdateDraft: (urn: string, updates: ImportEntityDraftUpdate) => void;
+};
+
+const STATUS_COLOR_MAP: Record<ImportEntityStatus, ColorValues> = {
+    READY: ColorValues.green,
+    CONFLICT: ColorValues.red,
+    NEW: ColorValues.violet,
+    SKIPPED: ColorValues.gray,
+};
+
+const ASPECT_CHANGE_COLOR_MAP: Record<string, ColorValues> = {
+    UPSERT: ColorValues.violet,
+    UPDATE: ColorValues.violet,
+    DELETE: ColorValues.red,
+    REMOVE: ColorValues.red,
+};
+
+const buildEntityRows = (rows: ImportEntityRow[], level = 0): EntityRowData[] =>
+    rows.map((row) => ({
+        key: row.urn,
+        name: row.urn,
+        urn: row.urn,
+        displayName: row.name,
+        originalName: row.originalName,
+        description: row.description,
+        originalDescription: row.originalDescription,
+        entityType: row.entityType,
+        status: row.status,
+        path: row.path,
+        level,
+        aspects: row.aspects,
+        children: row.children?.length ? buildEntityRows(row.children, level + 1) : undefined,
+    }));
+
+const EntityStatusPill = ({ status }: { status: ImportEntityStatus }) => (
+    <Pill
+        label={IMPORT_STATUS_COPY[status]?.label || status}
+        color={STATUS_COLOR_MAP[status]}
+        variant={PillVariantValues.outline}
+        size="sm"
+    />
+);
+
+type AspectsCellProps = {
+    row: EntityRowData;
+    draft?: ImportEntityDraft;
+    onUpdateDraft: (urn: string, updates: ImportEntityDraftUpdate) => void;
+};
+
+const AspectsCell: React.FC<AspectsCellProps> = ({ row, draft, onUpdateDraft }) => {
+    if (!row.aspects?.length) {
+        return (
+            <NoAspectsText color="gray" size="sm">
+                No aspect updates
+            </NoAspectsText>
+        );
+    }
+
+    return (
+        <AspectList>
+            {row.aspects.map((aspect) => {
+                const draftValue = draft?.aspects?.[aspect.name];
+                const previewValue = aspect.value ?? '';
+                const currentValue = draftValue !== undefined ? draftValue ?? '' : previewValue ?? '';
+                const originalValue = aspect.originalValue ?? '';
+                const hasOriginalValue = (aspect.originalValue ?? '').trim().length > 0;
+                const hasChanged = currentValue !== originalValue;
+                const changeType = aspect.changeType || '';
+                const changeColor = ASPECT_CHANGE_COLOR_MAP[changeType] || ColorValues.gray;
+
+                const editor = (
+                    <InlineTextArea
+                        value={currentValue}
+                        onChange={(event) =>
+                            onUpdateDraft(row.urn, { aspects: { [aspect.name]: event.currentTarget.value } })
+                        }
+                        placeholder="Update aspect payload"
+                        label=""
+                    />
+                );
+
+                return (
+                    <AspectItem key={aspect.name}>
+                        <AspectHeader>
+                            <AspectLabel size="sm">{aspect.label}</AspectLabel>
+                            {changeType && (
+                                <Pill
+                                    label={changeType}
+                                    color={changeColor}
+                                    variant={PillVariantValues.outline}
+                                    size="xs"
+                                />
+                            )}
+                        </AspectHeader>
+                        {aspect.description && (
+                            <Text size="xs" color="gray">
+                                {aspect.description}
+                            </Text>
+                        )}
+                        {hasChanged ? <ChangedField>{editor}</ChangedField> : editor}
+                        {hasOriginalValue ? (
+                            <AspectOriginalWrapper>
+                                <Text size="xs" color="gray">
+                                    Original value
+                                </Text>
+                                <AspectOriginal>{originalValue}</AspectOriginal>
+                            </AspectOriginalWrapper>
+                        ) : (
+                            <Text size="xs" color="gray">
+                                No previous value
+                            </Text>
+                        )}
+                    </AspectItem>
+                );
+            })}
+        </AspectList>
+    );
+};
+
+type EntityHierarchyTableProps = {
+    data: EntityRowData[];
+    drafts: Record<string, ImportEntityDraft>;
+    onUpdateDraft: (urn: string, updates: ImportEntityDraftUpdate) => void;
+    isLoading?: boolean;
+};
+
+const EntityHierarchyTable = ({ data, drafts, onUpdateDraft, isLoading }: EntityHierarchyTableProps) => {
+    const [expandedRowUrns, setExpandedRowUrns] = useState<string[]>([]);
+
+    const toggleRow = (row: EntityRowData) => {
+        setExpandedRowUrns((prev) =>
+            prev.includes(row.name) ? prev.filter((urn) => urn !== row.name) : [...prev, row.name],
+        );
+    };
+
+    const columns = useMemo(
+        () => [
+            {
+                title: 'Entity',
+                key: 'entity',
+                render: (row: EntityRowData) => {
+                    const draft = drafts[row.urn];
+                    const finalName = draft?.name ?? row.displayName;
+                    const content = (
+                        <EntityNameCell $level={row.level}>
+                            <Text weight="bold">{finalName}</Text>
+                            <Text color="gray" size="sm">
+                                {row.entityType}
+                            </Text>
+                            {!!row.path?.length && <PathText size="xs">{row.path.join(' / ')}</PathText>}
+                        </EntityNameCell>
+                    );
+                    return finalName !== row.originalName ? <ChangedField>{content}</ChangedField> : content;
+                },
+            },
+            {
+                title: 'Updated Name',
+                key: 'name',
+                render: (row: EntityRowData) => {
+                    const draft = drafts[row.urn];
+                    const value = draft?.name ?? row.displayName;
+                    const hasChanged = value !== row.originalName;
+                    const content = (
+                        <InlineInput
+                            value={value}
+                            setValue={(next) => onUpdateDraft(row.urn, { name: next })}
+                            placeholder="Entity name"
+                            label=""
+                        />
+                    );
+                    return hasChanged ? <ChangedField>{content}</ChangedField> : content;
+                },
+            },
+            {
+                title: 'Updated Description',
+                key: 'description',
+                render: (row: EntityRowData) => {
+                    const draft = drafts[row.urn];
+                    const preview = row.description ?? '';
+                    const value = draft?.description ?? preview;
+                    const original = row.originalDescription ?? '';
+                    const hasChanged = value !== original;
+                    const content = (
+                        <InlineTextArea
+                            value={value}
+                            onChange={(event) => onUpdateDraft(row.urn, { description: event.currentTarget.value })}
+                            placeholder="Describe the entity"
+                            label=""
+                        />
+                    );
+                    return hasChanged ? <ChangedField>{content}</ChangedField> : content;
+                },
+            },
+            {
+                title: 'Status',
+                key: 'status',
+                width: '160px',
+                render: (row: EntityRowData) => <EntityStatusPill status={row.status} />,
+            },
+            {
+                title: 'Aspect Updates',
+                key: 'aspects',
+                render: (row: EntityRowData) => (
+                    <AspectsCell row={row} draft={drafts[row.urn]} onUpdateDraft={onUpdateDraft} />
+                ),
+            },
+        ],
+        [drafts, onUpdateDraft],
+    );
+
+    return (
+        <Table<EntityRowData>
+            columns={columns}
+            data={data}
+            isLoading={isLoading}
+            rowKey={(row: EntityRowData) => row.key}
+            onRowClick={toggleRow}
+            expandable={{
+                rowExpandable: (row: EntityRowData) => !!row.children?.length,
+                expandedGroupIds: expandedRowUrns,
+                expandedRowRender: (row: EntityRowData) =>
+                    row.children ? (
+                        <EntityHierarchyTable data={row.children} drafts={drafts} onUpdateDraft={onUpdateDraft} />
+                    ) : null,
+            }}
+            isBorderless
+        />
+    );
+};
+
+export const ImportEntitiesTable = ({ rows, drafts, loading, onUpdateDraft }: ImportEntitiesTableProps) => {
+    const entityRows = useMemo(() => buildEntityRows(rows), [rows]);
+
+    return (
+        <TableWrapper>
+            <EntityHierarchyTable data={entityRows} drafts={drafts} onUpdateDraft={onUpdateDraft} isLoading={loading} />
+        </TableWrapper>
+    );
+};
+
+export const StatusSummary = ({ counts }: { counts: Record<ImportEntityStatus, number> }) => {
+    const statuses = (Object.keys(counts) as ImportEntityStatus[]).filter((status) => counts[status] > 0);
+
+    if (!statuses.length) {
+        return <Text color="gray">No entities</Text>;
+    }
+
+    return (
+        <StatusContainer>
+            {statuses.map((status) => (
+                <StatusGroup key={status}>
+                    <Pill
+                        label={IMPORT_STATUS_COPY[status]?.label || status}
+                        color={STATUS_COLOR_MAP[status]}
+                        variant={PillVariantValues.filled}
+                        size="sm"
+                    />
+                    <Text color="gray" size="sm">
+                        {counts[status]}
+                    </Text>
+                </StatusGroup>
+            ))}
+        </StatusContainer>
+    );
+};

--- a/datahub-web-react/src/app/import/constants.ts
+++ b/datahub-web-react/src/app/import/constants.ts
@@ -1,0 +1,36 @@
+export const DEFAULT_PAGE_SIZE = 25;
+
+export const GLOSSARY_GROUP_KEY = 'GLOSSARY';
+
+export const ENTITY_GROUP_LABELS: Record<string, string> = {
+    DATASET: 'Datasets',
+    DATAFLOW: 'Pipelines',
+    DATAJOB: 'Jobs',
+    DATA_PLATFORM: 'Platforms',
+    DASHBOARD: 'Dashboards',
+    CHART: 'Charts',
+    CONTAINER: 'Containers',
+    GLOSSARY: 'Glossary',
+    GLOSSARY_NODE: 'Glossary',
+    GLOSSARY_TERM: 'Glossary',
+    DOMAIN: 'Domains',
+};
+
+export const IMPORT_STATUS_COPY: Record<string, { label: string; helperText: string }> = {
+    READY: {
+        label: 'Ready',
+        helperText: 'All fields validated',
+    },
+    CONFLICT: {
+        label: 'Needs Review',
+        helperText: 'Conflicting metadata detected',
+    },
+    NEW: {
+        label: 'New Entity',
+        helperText: 'This entity will be created',
+    },
+    SKIPPED: {
+        label: 'Skipped',
+        helperText: 'No changes applied',
+    },
+};

--- a/datahub-web-react/src/app/import/types.ts
+++ b/datahub-web-react/src/app/import/types.ts
@@ -1,0 +1,58 @@
+export type ImportEntityStatus = 'READY' | 'CONFLICT' | 'NEW' | 'SKIPPED';
+
+export type ImportEntityAspect = {
+    name: string;
+    label: string;
+    description?: string | null;
+    value?: string | null;
+    originalValue?: string | null;
+    changeType?: string | null;
+};
+
+export type ImportEntityRow = {
+    urn: string;
+    entityType: string;
+    name: string;
+    description?: string | null;
+    originalName: string;
+    originalDescription?: string | null;
+    status: ImportEntityStatus;
+    path: string[];
+    parentUrn?: string | null;
+    children?: ImportEntityRow[];
+    aspects?: ImportEntityAspect[];
+};
+
+export type ImportEntityGroup = {
+    id: string;
+    label: string;
+    total: number;
+    statusCounts: Record<ImportEntityStatus, number>;
+    rows: ImportEntityRow[];
+};
+
+export type ImportEntityDraft = {
+    name?: string;
+    description?: string | null;
+    aspects?: Record<string, string | null>;
+};
+
+export type ImportEntityDraftUpdate = {
+    name?: string;
+    description?: string | null;
+    aspects?: Record<string, string | null>;
+};
+
+export type ImportEntitiesQueryVariables = {
+    start: number;
+    count: number;
+    query?: string;
+    group?: string;
+};
+
+export type ImportEntitiesQueryResult = {
+    groups: ImportEntityGroup[];
+    start: number;
+    count: number;
+    total: number;
+};

--- a/datahub-web-react/src/app/import/useImportEntities.ts
+++ b/datahub-web-react/src/app/import/useImportEntities.ts
@@ -1,0 +1,452 @@
+import { gql, useQuery } from '@apollo/client';
+import { useMemo } from 'react';
+
+import { ENTITY_GROUP_LABELS, GLOSSARY_GROUP_KEY } from '@app/import/constants';
+import {
+    ImportEntitiesQueryResult,
+    ImportEntitiesQueryVariables,
+    ImportEntityGroup,
+    ImportEntityRow,
+    ImportEntityStatus,
+} from '@app/import/types';
+
+const IMPORT_ENTITIES_PREVIEW_QUERY = gql`
+    query importEntitiesPreview($input: ImportEntitiesPreviewInput!) {
+        importEntitiesPreview(input: $input) {
+            start
+            count
+            total
+            groups {
+                id
+                name
+                type
+                total
+                statusCounts {
+                    READY
+                    CONFLICT
+                    NEW
+                    SKIPPED
+                }
+                entities {
+                    urn
+                    entityType
+                    name
+                    description
+                    originalName
+                    originalDescription
+                    status
+                    path
+                    parentUrn
+                    aspects {
+                        aspectName
+                        displayName
+                        description
+                        newValue
+                        previousValue
+                        changeType
+                    }
+                    children {
+                        urn
+                        entityType
+                        name
+                        description
+                        originalName
+                        originalDescription
+                        status
+                        path
+                        parentUrn
+                        aspects {
+                            aspectName
+                            displayName
+                            description
+                            newValue
+                            previousValue
+                            changeType
+                        }
+                    }
+                }
+                groups {
+                    id
+                    name
+                    type
+                    total
+                    statusCounts {
+                        READY
+                        CONFLICT
+                        NEW
+                        SKIPPED
+                    }
+                    entities {
+                        urn
+                        entityType
+                        name
+                        description
+                        originalName
+                        originalDescription
+                        status
+                        path
+                        parentUrn
+                        aspects {
+                            aspectName
+                            displayName
+                            description
+                            newValue
+                            previousValue
+                            changeType
+                        }
+                        children {
+                            urn
+                            entityType
+                            name
+                            description
+                            originalName
+                            originalDescription
+                            status
+                            path
+                            parentUrn
+                            aspects {
+                                aspectName
+                                displayName
+                                description
+                                newValue
+                                previousValue
+                                changeType
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`;
+
+type ImportEntitiesPreviewResponse = {
+    importEntitiesPreview?: {
+        start?: number;
+        count?: number;
+        total?: number;
+        groups?: RawImportGroup[];
+    } | null;
+};
+
+type RawImportGroup = {
+    id?: string | null;
+    name?: string | null;
+    type?: string | null;
+    total?: number | null;
+    statusCounts?: Partial<Record<ImportEntityStatus, number>> | null;
+    entities?: RawImportEntity[] | null;
+    groups?: RawImportGroup[] | null;
+};
+
+type RawImportEntity = {
+    urn?: string | null;
+    entityType?: string | null;
+    name?: string | null;
+    description?: string | null;
+    originalName?: string | null;
+    originalDescription?: string | null;
+    status?: ImportEntityStatus | null;
+    path?: string[] | null;
+    parentUrn?: string | null;
+    children?: RawImportEntity[] | null;
+    aspects?: RawImportAspect[] | null;
+};
+
+type RawImportAspect = {
+    aspectName?: string | null;
+    displayName?: string | null;
+    description?: string | null;
+    newValue?: unknown;
+    previousValue?: unknown;
+    changeType?: string | null;
+};
+
+const EMPTY_RESULT: ImportEntitiesQueryResult = {
+    start: 0,
+    count: 0,
+    total: 0,
+    groups: [],
+};
+
+const DEFAULT_STATUS_COUNTS: Record<ImportEntityStatus, number> = {
+    READY: 0,
+    CONFLICT: 0,
+    NEW: 0,
+    SKIPPED: 0,
+};
+
+const ensureStatusCounts = (
+    counts?: Partial<Record<ImportEntityStatus, number>> | null,
+): Record<ImportEntityStatus, number> => {
+    const result = { ...DEFAULT_STATUS_COUNTS };
+    if (!counts) {
+        return result;
+    }
+    (Object.keys(DEFAULT_STATUS_COUNTS) as ImportEntityStatus[]).forEach((status) => {
+        result[status] = counts[status] || 0;
+    });
+    return result;
+};
+
+const normalizeGroupKey = (group?: RawImportGroup) => {
+    const key = group?.type || group?.id || 'UNKNOWN';
+    if (key === 'GLOSSARY_NODE' || key === 'GLOSSARY_TERM') {
+        return GLOSSARY_GROUP_KEY;
+    }
+    return key;
+};
+
+const mergeStatusCounts = (
+    target: Record<ImportEntityStatus, number>,
+    incoming?: Partial<Record<ImportEntityStatus, number>> | null,
+) => {
+    const next = { ...target };
+    if (!incoming) {
+        return next;
+    }
+    (Object.keys(DEFAULT_STATUS_COUNTS) as ImportEntityStatus[]).forEach((status) => {
+        next[status] = (next[status] || 0) + (incoming?.[status] || 0);
+    });
+    return next;
+};
+
+const computeStatusCountsFromRows = (rows: ImportEntityRow[]) => {
+    const counts = { ...DEFAULT_STATUS_COUNTS };
+    rows.forEach((row) => {
+        counts[row.status] = (counts[row.status] || 0) + 1;
+        if (row.children?.length) {
+            const childCounts = computeStatusCountsFromRows(row.children);
+            (Object.keys(DEFAULT_STATUS_COUNTS) as ImportEntityStatus[]).forEach((status) => {
+                counts[status] = (counts[status] || 0) + childCounts[status];
+            });
+        }
+    });
+    return counts;
+};
+
+const stringifyAspectValue = (value: unknown) => {
+    if (value === null || value === undefined) {
+        return null;
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch (e) {
+        return String(value);
+    }
+};
+
+const transformAspect = (aspect: RawImportAspect) => {
+    const name = aspect.aspectName || 'unknown';
+    return {
+        name,
+        label: aspect.displayName || name,
+        description: aspect.description,
+        value: stringifyAspectValue(aspect.newValue),
+        originalValue: stringifyAspectValue(aspect.previousValue),
+        changeType: aspect.changeType,
+    };
+};
+
+const transformEntity = (entity: RawImportEntity): ImportEntityRow => {
+    const children = (entity.children || [])
+        .filter((child): child is RawImportEntity => !!child)
+        .map((child) => transformEntity(child));
+    const status = (entity.status as ImportEntityStatus) || 'READY';
+    const aspects = (entity.aspects || [])
+        .filter((aspect): aspect is RawImportAspect => !!aspect)
+        .map((aspect) => transformAspect(aspect));
+    return {
+        urn: entity.urn || `pending-${Math.random().toString(36).slice(2)}`,
+        entityType: entity.entityType || 'UNKNOWN',
+        name: entity.name || '',
+        originalName: entity.originalName || entity.name || '',
+        description: entity.description,
+        originalDescription: entity.originalDescription ?? entity.description,
+        status,
+        path: entity.path || [],
+        parentUrn: entity.parentUrn,
+        children,
+        aspects,
+    };
+};
+
+const transformGroup = (group: RawImportGroup): ImportEntityGroup => {
+    const rows = (group.entities || [])
+        .filter((entity): entity is RawImportEntity => !!entity)
+        .map((entity) => transformEntity(entity));
+
+    const nestedGroups = (group.groups || [])
+        .filter((child): child is RawImportGroup => !!child)
+        .map((child) => transformGroup(child));
+
+    nestedGroups.forEach((nestedGroup) => {
+        rows.push(...nestedGroup.rows);
+    });
+
+    const computedCounts = computeStatusCountsFromRows(rows);
+    const providedCounts = ensureStatusCounts(group.statusCounts as Partial<Record<ImportEntityStatus, number>>);
+    const hasProvidedCounts = (Object.keys(DEFAULT_STATUS_COUNTS) as ImportEntityStatus[]).some(
+        (status) => providedCounts[status] > 0,
+    );
+    const statusCounts = hasProvidedCounts ? providedCounts : computedCounts;
+
+    const key = normalizeGroupKey(group);
+    const label = group.name || ENTITY_GROUP_LABELS[key] || key;
+
+    return {
+        id: key,
+        label,
+        total: group.total || rows.length,
+        statusCounts,
+        rows,
+    };
+};
+
+const flattenRows = (rows: ImportEntityRow[], accumulator: ImportEntityRow[] = []) => {
+    rows.forEach((row) => {
+        accumulator.push({ ...row, children: undefined });
+        if (row.children?.length) {
+            flattenRows(row.children, accumulator);
+        }
+    });
+    return accumulator;
+};
+
+const buildHierarchyByParent = (rows: ImportEntityRow[]) => {
+    const cloneMap = new Map<string, ImportEntityRow>();
+    const roots: ImportEntityRow[] = [];
+
+    rows.forEach((row) => {
+        cloneMap.set(row.urn, { ...row, children: [] });
+    });
+
+    rows.forEach((row) => {
+        const clone = cloneMap.get(row.urn);
+        if (!clone) {
+            return;
+        }
+        if (row.parentUrn && cloneMap.has(row.parentUrn)) {
+            const parent = cloneMap.get(row.parentUrn);
+            if (parent) {
+                parent.children = parent.children || [];
+                parent.children.push(clone);
+            }
+            return;
+        }
+        roots.push(clone);
+    });
+
+    const finalize = (items: ImportEntityRow[]): ImportEntityRow[] =>
+        items.map((item) => ({
+            ...item,
+            children: item.children && item.children.length ? finalize(item.children) : undefined,
+        }));
+
+    return finalize(roots);
+};
+
+const groupRowsByEntityType = (groups: ImportEntityGroup[]): ImportEntityGroup[] => {
+    const byEntityType = new Map<
+        string,
+        {
+            label: string;
+            rows: ImportEntityRow[];
+            statusCounts: Record<ImportEntityStatus, number>;
+        }
+    >();
+
+    groups.forEach((group) => {
+        const flattened = flattenRows(group.rows);
+        flattened.forEach((row) => {
+            const key = normalizeGroupKey({ type: row.entityType });
+            const existing = byEntityType.get(key);
+            const label = ENTITY_GROUP_LABELS[key] || row.entityType || key;
+            const statusCounts = existing?.statusCounts || { ...DEFAULT_STATUS_COUNTS };
+            statusCounts[row.status] = (statusCounts[row.status] || 0) + 1;
+            const rowsForGroup = existing?.rows || [];
+            rowsForGroup.push(row);
+            byEntityType.set(key, {
+                label,
+                rows: rowsForGroup,
+                statusCounts,
+            });
+        });
+    });
+
+    return Array.from(byEntityType.entries()).map(([key, value]) => ({
+        id: key,
+        label: value.label,
+        total: value.rows.length,
+        statusCounts: value.statusCounts,
+        rows: buildHierarchyByParent(value.rows),
+    }));
+};
+
+const mergeGroupsByKey = (groups: RawImportGroup[]) => {
+    const accumulator = new Map<string, RawImportGroup>();
+    groups.forEach((group) => {
+        const key = normalizeGroupKey(group);
+        const existing = accumulator.get(key);
+        if (!existing) {
+            accumulator.set(key, { ...group, id: key, type: key });
+            return;
+        }
+        const merged: RawImportGroup = {
+            ...existing,
+            total: (existing.total || 0) + (group.total || 0),
+            statusCounts: mergeStatusCounts(
+                ensureStatusCounts(existing.statusCounts as Partial<Record<ImportEntityStatus, number>>),
+                group.statusCounts as Partial<Record<ImportEntityStatus, number>>,
+            ),
+            entities: [...(existing.entities || []), ...(group.entities || [])],
+            groups: [...(existing.groups || []), ...(group.groups || [])],
+        };
+        accumulator.set(key, merged);
+    });
+    return Array.from(accumulator.values());
+};
+
+export const buildImportVariables = ({ start, count, query, group }: ImportEntitiesQueryVariables) => ({
+    input: {
+        start,
+        count,
+        query: query || undefined,
+        group: group || undefined,
+    },
+});
+
+export function useImportEntities(variables: ImportEntitiesQueryVariables) {
+    const { data, loading, error, refetch } = useQuery<ImportEntitiesPreviewResponse>(
+        IMPORT_ENTITIES_PREVIEW_QUERY,
+        {
+            variables: buildImportVariables(variables),
+            fetchPolicy: 'cache-and-network',
+        },
+    );
+
+    const result = useMemo<ImportEntitiesQueryResult>(() => {
+        if (!data?.importEntitiesPreview) {
+            return EMPTY_RESULT;
+        }
+        const mergedGroups = mergeGroupsByKey(data.importEntitiesPreview.groups || []);
+        const groupsBySource = mergedGroups.map((group) => transformGroup(group));
+        const groups = groupRowsByEntityType(groupsBySource);
+        return {
+            start: data.importEntitiesPreview.start || 0,
+            count: data.importEntitiesPreview.count || 0,
+            total: data.importEntitiesPreview.total || 0,
+            groups,
+        };
+    }, [data]);
+
+    return {
+        data: result,
+        loading,
+        error,
+        refetch,
+    };
+}

--- a/datahub-web-react/src/conf/Global.ts
+++ b/datahub-web-react/src/conf/Global.ts
@@ -36,6 +36,7 @@ export enum PageRoutes {
     DATA_PRODUCTS = '/search?filter__entityType___false___EQUAL___0=DATA_PRODUCT&page=1&query=%2A&unionType=0',
     MANAGE_TAGS = '/tags',
     MANAGE_APPLICATIONS = '/applications',
+    IMPORT_ENTITIES = '/import/entities',
 }
 
 export enum HelpLinkRoutes {


### PR DESCRIPTION
## Summary
- restructure the import preview hook to group rows by entity type tabs and rebuild parent-child hierarchies from parent URNs
- update the import table to render hierarchical rows with inline aspect editors and highlight overrides
- fetch aspect previews/originals and build comprehensive patch operations so imports capture all aspect updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e27c747494832cbcd4985490013800